### PR TITLE
Include standard architecture

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,10 @@
+# The module makes repeated use of the try() function so requires a very recent
+# release of Terraform 0.12
+terraform {
+  required_version = ">= 0.12.20"
+  experiments      = [variable_validation]
+}
+
 provider "aws" {
   version = "~> 2.0"
   region  = var.region
@@ -26,6 +33,7 @@ module "loadbalancer" {
   project            = var.project
   region             = var.region
   instances          = module.instances.compilers
+  architecture       = var.architecture
 }
 
 # Instance module called from a dynamic source dependent on deploying 
@@ -44,6 +52,7 @@ module "instances" {
   user               = var.user
   ssh_key            = var.ssh_key
   compiler_count     = var.compiler_count
+  node_count         = var.node_count
   instance_image     = var.instance_image
   project            = var.project
   architecture       = var.architecture

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -1,8 +1,8 @@
-# This datasource will produce the most recent AMI
-# with the name pattern as provided in var.instance_image
-# and owner as specified.
-# To use AMIs by this owner, an EULA has to be acccepted once
-# using the AWS Console.
+# This data source will produce the most recent AMI with the name pattern as
+# provided in var.instance_image and owner as specified.
+#
+# To use AMIs by this owner, an EULA has to be accepted once using the AWS
+# Console.
 data "aws_ami" "centos7" {
   most_recent = true
 
@@ -48,9 +48,9 @@ resource "aws_instance" "master" {
   # $ ssh-add
   provisioner "remote-exec" {
     connection {
-      host = self.public_ip
-      type = "ssh"
-      user = var.user
+      host        = self.public_ip
+      type        = "ssh"
+      user        = var.user
     }
     inline = ["# Connected"]
   }
@@ -80,9 +80,9 @@ resource "aws_instance" "psql" {
   # $ ssh-add
   provisioner "remote-exec" {
     connection {
-      host = self.public_ip
-      type = "ssh"
-      user = var.user
+      host        = self.public_ip
+      type        = "ssh"
+      user        = var.user
     }
     inline = ["# Connected"]
   }
@@ -93,20 +93,13 @@ resource "aws_instance" "psql" {
 resource "aws_instance" "compiler" {
   ami                    = data.aws_ami.centos7.id
   instance_type          = "t3.xlarge"
-  count                  = var.compiler_count
+  count                  = var.architecture == "standard" ? 0 : var.compiler_count
   key_name               = aws_key_pair.pe_adm.key_name
   subnet_id              = var.subnet_ids[count.index % length(var.subnet_ids)]
   vpc_security_group_ids = var.security_group_ids
   tags                   = merge(var.default_tags, map("Name", "pe-compiler-${var.project}-${count.index}-${var.id}"))
   # vpc_security_group_ids = list()
   # zone          = element(var.zones, count.index)
-
-  # Old style internal DNS easiest until Bolt inventory dynamic
-  # metadata = {
-  #   "sshKeys"      = "${var.user}:${file(var.ssh_key)}"
-  #   "VmDnsSetting" = "ZonalPreferred"
-  #   "internalDNS"  = "pe-compiler-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
-  # }
 
   root_block_device {
     volume_size = 15
@@ -122,11 +115,10 @@ resource "aws_instance" "compiler" {
   # $ ssh-add
   provisioner "remote-exec" {
     connection {
-      host = self.public_ip
-      type = "ssh"
-      user = var.user
+      host        = self.public_ip
+      type        = "ssh"
+      user        = var.user
     }
     inline = ["# Connected"]
   }
-
 }

--- a/modules/instances/outputs.tf
+++ b/modules/instances/outputs.tf
@@ -1,10 +1,10 @@
 # Output data used by Bolt to do further work, doing this allows for a clean and
 # abstracted interface between cloud provider implementations
 output "console" {
-  value       = aws_instance.master[0].public_ip
+  value       = try(aws_instance.master[0].public_ip, "")
   description = "Public IP address assigned to the Puppet Enterprise console"
 }
 output "compilers" {
-  value       = aws_instance.compiler[*].id
+  value       = var.architecture == "standard" ? aws_instance.master[*] : aws_instance.compiler[*] 
   description = "AWS Instance ID of the Puppet compilers"
 }

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,7 +1,8 @@
-# variable "id" {
-#   description = "Name of GCP project that will be used for housing require infrastructure"
-#   type        = string
-# }
+# These are the variables required for the instances submodule to function
+# properly and are duplicated highly from the main module but instead do not
+# have any defaults set because this submodule should never by called from
+# anything else expect the main module where values for all these variables will
+# always be passed in
 variable "user" {
   description = "Instance user name that will used for SSH operations"
   type        = string
@@ -9,20 +10,23 @@ variable "user" {
 variable "ssh_key" {
   description = "Location on disk of the SSH public key to be used for instance SSH access"
   type        = string
-  default     = "~/.ssh/id_rsa.pub"
 }
 variable "compiler_count" {
   description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
   type        = number
-  default     = 3
 }
-variable id {}
+variable "id" {
+  description = "Randomly generated value used to produce unique names for everything to prevent collisions and visually link resources together"
+  type        = string
+}
+
 variable vpc_id {}
 variable subnet_ids {}
 variable security_group_ids {}
 variable project {}
 variable architecture {}
 variable instance_image {}
+variable node_count {}
 # The default tags are needed to prevent Puppet AWS reaper from reaping the instances
 variable default_tags {
   description = "The default instance tags"

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -1,4 +1,5 @@
 resource "aws_elb" "pe_compiler_elb" {
+  count         = var.architecture == "standard" ? 0 : 1
   name            = "pe-compiler-elb-${var.project}-${var.id}"
   subnets         = var.subnet_ids
   security_groups = var.security_group_ids
@@ -24,7 +25,7 @@ resource "aws_elb" "pe_compiler_elb" {
     interval            = 30
   }
 
-  instances                   = var.instances
+  instances                   = var.instances[*].id
   cross_zone_load_balancing   = true
   idle_timeout                = 400
   connection_draining         = true

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,4 +1,4 @@
 output "lb_dns_name" {
-  value       = aws_elb.pe_compiler_elb.dns_name
+  value       = var.architecture == "standard" ? tolist(var.instances)[0].public_ip : try(aws_elb.pe_compiler_elb[0].dns_name, "")
   description = "The DNS name of a new Puppet Enterprise compiler LB"
 }

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -5,3 +5,4 @@ variable security_group_ids {}
 variable region {}
 variable instances {}
 variable project {}
+variable architecture {}

--- a/variables.tf
+++ b/variables.tf
@@ -17,17 +17,25 @@ variable "region" {
   type        = string
   default     = "eu-central-1"
 }
-# Not used in the AWS implementation
-# All available AWS availability zones in the region are used automatically"
-# variable "zones" {
-#   description = "AWS availability zones that are within the defined AWS region that you wish to use. Actually ignored in the current implementation - all available zones in the region are used automatically"
-#   type        = list(string)
-#   default     = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
-# }
 variable "compiler_count" {
   description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
   type        = number
   default     = 3
+
+  validation {
+    condition     = var.compiler_count >= 3
+    error_message = "The compiler_count variable must be greater or equal to 3."
+  }
+}
+variable "node_count" {
+  description = "The quantity of nodes that are deployed within the environment for testing"
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = length(regexall("^[[:digit:]]+.[[:digit:]]+$", tostring(var.node_count / 3))) == 0
+    error_message = "The node_count variable must be divisible by 3."
+  }
 }
 # Note that you might need to accept the AWS EULA for the AMI product used here
 variable "instance_image" {


### PR DESCRIPTION
	Steps towards finding parity between GCP and AWS implementations
	of the Terraform modules that back puppetlabs/autope