### PR TITLE
(SOLARCH-450) updating map and list functions to tomap and tolist

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "server" {
   key_name               = aws_key_pair.pe_adm.key_name
   subnet_id              = var.subnet_ids[count.index]
   vpc_security_group_ids = var.security_group_ids
-  tags                   = merge(var.default_tags, map("Name", "pe-server-${var.project}-${count.index}-${var.id}"))
+  tags                   = merge(var.default_tags, tomap({Name = "pe-server-${var.project}-${count.index}-${var.id}"}))
 
   root_block_device {
     volume_size = 50
@@ -72,7 +72,7 @@ resource "aws_instance" "psql" {
   key_name               = aws_key_pair.pe_adm.key_name
   subnet_id              = var.subnet_ids[count.index]
   vpc_security_group_ids = var.security_group_ids
-  tags                   = merge(var.default_tags, map("Name", "pe-psql-${var.project}-${count.index}-${var.id}"))
+  tags                   = merge(var.default_tags, tomap({Name = "pe-psql-${var.project}-${count.index}-${var.id}"}))
 
   root_block_device {
     volume_size = 100
@@ -111,7 +111,7 @@ resource "aws_instance" "compiler" {
   key_name               = aws_key_pair.pe_adm.key_name
   subnet_id              = var.subnet_ids[count.index % length(var.subnet_ids)]
   vpc_security_group_ids = var.security_group_ids
-  tags                   = merge(var.default_tags, map("Name", "pe-compiler-${var.project}-${count.index}-${var.id}"))
+  tags                   = merge(var.default_tags, tomap({Name = "pe-compiler-${var.project}-${count.index}-${var.id}"}))
 
   root_block_device {
     volume_size = 15
@@ -145,7 +145,7 @@ resource "aws_instance" "node" {
   key_name               = aws_key_pair.pe_adm.key_name
   subnet_id              = var.subnet_ids[count.index % length(var.subnet_ids)]
   vpc_security_group_ids = var.security_group_ids
-  tags                   = merge(var.default_tags, map("Name", "pe-node-${var.project}-${count.index}-${var.id}"))
+  tags                   = merge(var.default_tags, tomap({Name = "pe-node-${var.project}-${count.index}-${var.id}"}))
 
   root_block_device {
     volume_size = 15

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -70,7 +70,7 @@ resource "aws_security_group" "pe_sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1" # all protocols and ports
-    cidr_blocks = list(aws_vpc.pe.cidr_block)
+    cidr_blocks = tolist([aws_vpc.pe.cidr_block])
   }
 
   egress {


### PR DESCRIPTION
Using terraform 15 found the following issue. Fixed and tested as advised in

https://www.terraform.io/docs/language/functions/list.html
https://www.terraform.io/docs/language/functions/map.html

"
on modules/networking/main.tf line 73, in resource "aws_security_group" "pe_sg": 
  73:   cidr_blocks = tolist[(aws_vpc.pe.cidr_block)] 
  on modules/instances/main.tf line 37, in resource "aws_instance" "server": 
  37: tags          = merge(var.default_tags, map("Name", "pe-server-${var.project}-${count.index}-${var.id}")) 
    ├──────────────── 
    │ count.index is a number, known only after apply 
    │ var.id is a string, known only after apply 
    │ var.project is a string, known only after apply 
  Call to function "map" failed: the "map" function was deprecated in Terraform 
  v0.12 and is no longer available; use tomap({ ... }) syntax to write a 
  literal map. 
  Error: Error in function call 
   on modules/instances/main.tf line 75, in resource "aws_instance" "psql": 
  75: tags          = merge(var.default_tags, map("Name", "pe-psql-${var.project}-${count.index}-${var.id}")) 
    ├──────────────── 
    │ count.index is a number, known only after apply 
    │ var.id is a string, known only after apply 
    │ var.project is a string, known only after apply 
  Call to function "map" failed: the "map" function was deprecated in Terraform 
  v0.12 and is no longer available; use tomap({ ... }) syntax to write a 
  literal map. 
  Error: Error in function call 
   on modules/instances/main.tf line 114, in resource "aws_instance" "compiler": 
  114: tags          = merge(var.default_tags, map("Name", "pe-compiler-${var.project}-${count.index}-${var.id}")) 
    ├──────────────── 
    │ count.index is a number, known only after apply 
    │ var.id is a string, known only after apply 
    │ var.project is a string, known only after apply 
  Call to function "map" failed: the "map" function was deprecated in Terraform 
  v0.12 and is no longer available; use tomap({ ... }) syntax to write a 
  literal map. 
  Error: Error in function call 
   on modules/instances/main.tf line 148, in resource "aws_instance" "node": 
  148: tags          = merge(var.default_tags, map("Name", "pe-node-${var.project}-${count.index}-${var.id}")) 
    ├──────────────── 
    │ count.index is a number, known only after apply 
    │ var.id is a string, known only after apply 
    │ var.project is a string, known only after apply 
  Call to function "map" failed: the "map" function was deprecated in Terraform 
  v0.12 and is no longer available; use tomap({ ... }) syntax to write a 
  literal map.
"

