### PR TITLE
Convert from classic elb to nlb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ module "networking" {
 module "loadbalancer" {
   source             = "./modules/loadbalancer"
   id                 = local.id
+  vpc_id             = module.networking.vpc_id
   ports              = ["8140", "8142"]
   security_group_ids = module.networking.security_group_ids
   subnet_ids         = module.networking.subnet_ids
@@ -75,6 +76,7 @@ module "loadbalancer" {
   region             = var.region
   instances          = module.instances.compilers
   has_lb             = local.has_lb
+  compiler_count     = local.compiler_count
 }
 
 # Contain all the instances configuration in a module for readability

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,4 +1,4 @@
 output "lb_dns_name" {
-  value       = var.has_lb ? try(aws_elb.pe_compiler_elb[0].dns_name, "") : tolist(var.instances)[0].public_dns
+  value       = var.has_lb ? try(aws_lb.pe_compiler_service[0].dns_name, "") : tolist(var.instances)[0].public_dns
   description = "The DNS name of either the load balancer fronting the compiler pool or the primary master, depending on architecture"
 }

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -23,6 +23,10 @@ variable "has_lb" {
   description = "A boolean that indicates if the deployment requires load balancer deployment"
   type        = bool
 }
+variable "compiler_count" {
+  description = "Work around for inability of Terraform to be able to predict number of attachments"
+  type        = number 
+}
 variable subnet_ids {
     description = "AWS subnet ids that are created by the networking module"
 }
@@ -31,4 +35,7 @@ variable security_group_ids {
 }
 variable project {
   description = "Project string to differentiate and associate resources"
+}
+variable "vpc_id" {
+  description = "ID of VPC network provisioned by the networking submodule"
 }


### PR DESCRIPTION
Changes that facilitate and deploy a network load balancer (NLB) instead
of a classic load balancer, commonly known as an ELB so that we deliver
in our reference implementation the same services for which we recommend
architecturally