### PR TITLE
Removes use of the project variable within names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ module "instances" {
   compiler_count     = local.compiler_count
   node_count         = var.node_count
   instance_image     = var.instance_image
+  stack_name         = var.stack_name
   project            = var.project
   server_count       = data.hiera5.server_count.value
   database_count     = data.hiera5.database_count.value

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -44,18 +44,11 @@ variable "instance_image" {
   description = "The disk image to use when deploying new cloud instances"
   type        = string
 }
+variable "stack_name" {
+  description = "A name that'll help the user identify which instances are are part of a specific PE deployment"
+  type        = string
+}
 variable "node_count" {
   description = "The quantity of nodes that are deployed within the environment for testing"
   type        = number
-}
-# The default tags are needed to prevent Puppet AWS reaper from reaping the instances
-variable default_tags {
-  description = "The default instance tags"
-  type        = map
-  default = {
-    description = "PEADM Architecture"
-    department  = "SA"
-    project     = "peadm - autope"
-    lifetime    = "1d"
-  }
 }

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -7,7 +7,7 @@ locals {
 
 resource "aws_lb" "pe_compiler_service" {
   count                            = local.lb_count
-  name                             = "pe-compiler-lb-${var.project}-${var.id}"
+  name                             = "pe-compiler-lb-${var.id}"
   subnets                          = var.subnet_ids
   load_balancer_type               = "network"
   enable_cross_zone_load_balancing = true 
@@ -28,7 +28,7 @@ resource "aws_lb_listener" "pe_compiler" {
 
 resource "aws_lb_target_group" "pe_compiler" {
   for_each    = var.has_lb ? local.lb_ports : []
-  name        = "pe-tg-${var.project}-${var.id}-${each.value}"
+  name        = "pe-tg-${var.id}-${each.value}"
   port        = each.value
   protocol    = "TCP"
   target_type = "instance"

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,7 +1,7 @@
 # To contain each PE deployment, a fresh VPC to deploy into
 locals {
   name_tag = {
-    Name = "pe-${var.project}-${var.id}"
+    Name = "pe-${var.id}"
   }
 }
 
@@ -31,7 +31,7 @@ resource "aws_subnet" "pe_subnet" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "pe-${var.project}-${var.id}-${data.aws_availability_zones.available.names[count.index]}"
+    Name = "pe-${var.id}-${data.aws_availability_zones.available.names[count.index]}"
   }
 }
 
@@ -53,7 +53,7 @@ resource "aws_route_table_association" "pe_subnet_public" {
 # Instances should not be accessible by the open internet so a fresh VPC should
 # be restricted to organization allowed subnets
 resource "aws_security_group" "pe_sg" {
-  name        = "pe-${var.project}-${var.id}"
+  name        = "pe-${var.id}"
   description = "Allow TLS inbound traffic"
   vpc_id      = aws_vpc.pe.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "project" {
   description = "Name of the PE architecture project"
   type        = string
-  default     = "ape"
+  default     = "autope"
 }
 variable "user" {
   description = "Instance user name that will used for SSH operations"
@@ -33,6 +33,11 @@ variable "instance_image" {
   description = "The AMI name pattern to use when deploying new cloud instances"
   type        = string
   default     = "CentOS Linux 7*ENA*"
+}
+variable "stack_name" {
+  description = "A name that'll help the user identify which instances are are part of a specific PE deployment"
+  type        = string
+  default     = "puppet-enterprise"
 }
 variable "architecture" {
   description = "Which of the supported PE architectures modules to deploy infrastructure with"


### PR DESCRIPTION
Repurposes already existing project tag and makes it capable of be set
from the CLI variable. Adds stack_name parameter that can be used to
further group together resources.