### PR TITLE
Convert from CentOS default to AlmaLinux

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ provider "aws" {
   region  = var.region
 }
 
-# hiera lookps
+# hiera lookups
 data "hiera5" "server_count" {
   key = "server_count"
 }
@@ -63,14 +63,13 @@ data "hiera5" "database_disk" {
   key = "database_disk_size"
 }
 
-# It is intended that multiple deployments can be launched easily without
-# name colliding
+# Prevent name collisions when multiple PE deployments are provisioned within
+# the same AWS account
 resource "random_id" "deployment" {
   byte_length = 3
 }
 
-# Collect some repeated values used by each major component module into one to
-# make them easier to update
+# Repeated and computed values used by component modules
 locals {
   allowed            = concat(["10.128.0.0/9"], var.firewall_allow)
   compiler_count     = data.hiera5_bool.has_compilers.value ? var.compiler_count : 0
@@ -82,7 +81,7 @@ locals {
   image_product_code = try(local.image_list[2], null)
 }
 
-# Contain all the networking configuration in a module for readability
+# Contain all the networking configuration for readability
 module "networking" {
   source  = "./modules/networking"
   id      = local.id
@@ -90,7 +89,7 @@ module "networking" {
   allow   = local.allowed
 }
 
-# Contain all the loadbalancer configuration in a module for readability
+# Contain all the loadbalancer configuration for readability
 module "loadbalancer" {
   source             = "./modules/loadbalancer"
   id                 = local.id
@@ -105,12 +104,8 @@ module "loadbalancer" {
   compiler_count     = local.compiler_count
 }
 
-# Contain all the instances configuration in a module for readability
+# Contain all the instances configuration for readability
 # 
-# NOTE: you will need to add your private key corresponding to `ssh_key` 
-# to the ssh agent like so:
-# $ eval $(ssh-agent)
-# $ ssh-add
 module "instances" {
   source             = "./modules/instances"
   vpc_id             = module.networking.vpc_id

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -41,8 +41,17 @@ variable "project" {
   type        = string
 }
 variable "instance_image" {
-  description = "The disk image to use when deploying new cloud instances"
+  description = "The AMI name pattern to use when deploying new cloud instances"
   type        = string
+}
+variable "image_owner" {
+  description = "The AMI name pattern to use when deploying new cloud instances"
+  type        = string
+}
+variable "image_product_code" {
+  description = "The AMI name pattern to use when deploying new cloud instances"
+  type        = string
+  nullable    = true
 }
 variable "stack_name" {
   description = "A name that'll help the user identify which instances are are part of a specific PE deployment"

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -4,7 +4,7 @@
 # anything else expect the main module where values for all these variables will
 # always be passed in
 variable "user" {
-  description = "Instance user name that will used for SSH operations"
+  description = "Default instance user name that will used for SSH operations"
   type        = string
 }
 variable "ssh_key" {
@@ -12,49 +12,49 @@ variable "ssh_key" {
   type        = string
 }
 variable "compiler_count" {
-  description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
+  description = "The quantity of compilers that are provisioned behind a load balancer"
   type        = number
 }
 variable "server_count" {
-  description = "The quantity of nodes that are deployed within the environment for testing"
+  description = "The quantity of server nodes which are provisioned for the stack"
   type        = number
 }
 variable "database_count" {
-  description = "The quantity of nodes that are deployed within the environment for testing"
+  description = "The quantity of database nodes which are provisioned for the stack"
   type        = number
 }
 variable "id" {
-  description = "Randomly generated value used to produce unique names for everything to prevent collisions and visually link resources together"
+  description = "Randomly generated value used to produce unique names for everything"
   type        = string
 }
 variable "vpc_id" {
-  description = "ID of VPC network provisioned by the networking submodule"
+  description = "Randomly generated value used to produce unique names for everything"
 }
 variable "subnet_ids" {
-  description = "List of zonal subnet IDs provisioned by the networking submodule"
+  description = "AWS subnet ids that are provided by the networking module"
 }
 variable "security_group_ids" {
-  description = "List of SG IDs provisioned by the networking submodule"
+  description = "AWS security groups ids that are provided by the networking module"
 }
 variable "project" {
-  description = "Name of project that will be used for cosmetically linking resources together"
+  description = "The name of the PE deployment project to tag resources with"
   type        = string
 }
 variable "instance_image" {
-  description = "The AMI name pattern to use when deploying new cloud instances"
+  description = "The AMI name pattern to use when provisioning cloud instances"
   type        = string
 }
 variable "image_owner" {
-  description = "The AMI name pattern to use when deploying new cloud instances"
+  description = "The owner ID of the desired AMI to use for provisioned cloud instances"
   type        = string
 }
 variable "image_product_code" {
-  description = "The AMI name pattern to use when deploying new cloud instances"
+  description = "The product code of desired AMI when sourcing from the AWS Marketplace"
   type        = string
   nullable    = true
 }
 variable "stack_name" {
-  description = "A name that'll help the user identify which instances are are part of a specific PE deployment"
+  description = "A tag to group individual PE deployments within each project together"
   type        = string
 }
 variable "node_count" {

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -8,7 +8,7 @@ variable ports {
     type        = list(string)
 }
 variable "region" {
-  description = "GCP region that'll be targeted for infrastructure deployment"
+  description = "AWS region that'll be targeted for infrastructure deployment"
   type        = string
 }
 variable instances {
@@ -16,7 +16,7 @@ variable instances {
     type        = set(any)
 }
 variable "id" {
-  description = "Randomly generated value used to produce unique names for everything to prevent collisions and visually link resources together"
+  description = "Randomly generated value used to produce unique names for everything"
   type        = string
 }
 variable "has_lb" {
@@ -24,18 +24,18 @@ variable "has_lb" {
   type        = bool
 }
 variable "compiler_count" {
-  description = "Work around for inability of Terraform to be able to predict number of attachments"
+  description = "The quantity of compilers that are deployed behind a load balancer"
   type        = number 
 }
 variable subnet_ids {
-    description = "AWS subnet ids that are created by the networking module"
+    description = "AWS subnet ids that are provided by the networking module"
 }
 variable security_group_ids {
-    description = "AWS security groups ids that are created by the networking module"
+    description = "AWS security groups ids that are provided by the networking module"
 }
 variable project {
-  description = "Project string to differentiate and associate resources"
+  description = "The name of the PE deployment project to tag resources with"
 }
 variable "vpc_id" {
-  description = "ID of VPC network provisioned by the networking submodule"
+  description = "Randomly generated value used to produce unique names for everything"
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -3,7 +3,7 @@
 # be called from anything else expect the main module where values for all these
 # variables will always be passed in
 variable id {
-  description = "Randomly generated value used to produce unique names for everything to prevent collisions and visually link resources together"
+  description = "Randomly generated value used to produce unique names for everything"
   type        = string
 }
 variable allow {
@@ -11,5 +11,5 @@ variable allow {
   type        = list(string)
 }
 variable project {
-  description = "Project string to differentiate and associate resources"
+  description = "The name of the PE deployment project to tag resources with"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "node_count" {
 variable "instance_image" {
   description = "The AMI name pattern to use when deploying new cloud instances"
   type        = string
-  default     = "CentOS Linux 7*ENA*"
+  default     = "764336703387/AlmaLinux OS 8*"
 }
 variable "stack_name" {
   description = "A name that'll help the user identify which instances are are part of a specific PE deployment"

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 variable "project" {
-  description = "Name of the PE architecture project"
+  description = "The name of the PE deployment project to tag resources with"
   type        = string
-  default     = "autope"
+  default     = "pecdm"
 }
 variable "user" {
-  description = "Instance user name that will used for SSH operations"
+  description = "Default instance user name that will used for SSH operations"
   type        = string
-  default     = "centos"
+  default     = "ec2-user"
 }
 variable "ssh_key" {
   description = "Location on disk of the SSH public key to be used for instance SSH access"
@@ -16,10 +16,10 @@ variable "ssh_key" {
 variable "region" {
   description = "AWS region that'll be targeted for infrastructure deployment"
   type        = string
-  default     = "eu-central-1"
+  default     = "us-west-2"
 }
 variable "compiler_count" {
-  description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
+  description = "The quantity of compilers that are provisioned behind a load balancer"
   type        = number
   default     = 1
 }
@@ -28,29 +28,31 @@ variable "node_count" {
   type        = number
   default     = 0
 }
-# Note that you might need to accept the AWS EULA for the AMI product used here
+# If you provision from Marketplace then you might need to accept the AWS EULA
+# for the AMI product used, default comes directly from AlmaLinux and no
+# additional steps are required
 variable "instance_image" {
   description = "The AMI name pattern to use when deploying new cloud instances"
   type        = string
   default     = "764336703387/AlmaLinux OS 8*"
 }
 variable "stack_name" {
-  description = "A name that'll help the user identify which instances are are part of a specific PE deployment"
+  description = "A tag to group individual PE deployments within each project together"
   type        = string
   default     = "puppet-enterprise"
 }
 variable "architecture" {
-  description = "Which of the supported PE architectures modules to deploy infrastructure with"
+  description = "Which of the supported PE architectures modules to provision infrastructure for"
   type        = string
   default     = "large"
 }
 variable "firewall_allow" {
-  description = "List of permitted IP subnets, list most include the internal network and single addresses must be passed as a /32"
+  description = "List of permitted IP addresses, all entries must be provided in CIDR Subnet Mask Notation"
   type        = list(string)
   default     = []
 }
 variable "replica" {
-  description = "To deploy instances required for the provisioning of a server replica"
+  description = "To provision instances required for the deploying a primary server replica"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Go from default of CentOS provided through the Marketplace to publicly
publushed release of AlmaLinux AMI. To accomplish this, the pattern used
to set the instance_image variable now resembles GCP, owner and name
pattern seperated by a forward slash (/).

If one wishes to still source images from the Marketplace, they still
can by setting owner to 679593333241 and additionally appending a second
foward slash and the product code, e.g. the Official AlmaLinux product
code is be714bpjscoj5uvqz0of5mscl.

Example:

  terraform apply -var "instance_image=679593333241/AlmaLinux OS 8*/be714bpjscoj5uvqz0of5mscl"

If you do not provide a product code when sourcing from the Marketplace
you will very likely end up sourcing the wrong image! This is because
Terraform returns the most recently published Marketplace AMI which
matches the image name pattern.