### PR TITLE
Ensure all data is returned

### DIFF
--- a/modules/instances/outputs.tf
+++ b/modules/instances/outputs.tf
@@ -1,7 +1,7 @@
 # Output data that will be used by other submodules to build other parts of the
 # stack to support defined architecture
 output "console" {
-  value       = try(aws_instance.server[0].public_ip, "")
+  value       = coalesce(aws_instance.server[0].public_ip, aws_instance.server[0].private_ip)
   description = "This will be the external IP address assigned to the Puppet Enterprise console"
 }
 output "compilers" {

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,4 +1,4 @@
 output "lb_dns_name" {
-  value       = var.has_lb ? try(aws_lb.pe_compiler_service[0].dns_name, "") : tolist(var.instances)[0].public_dns
+  value       = var.has_lb ? try(aws_lb.pe_compiler_service[0].dns_name, "") : coalesce(tolist(var.instances)[0].public_dns, tolist(var.instances)[0].private_dns)
   description = "The DNS name of either the load balancer fronting the compiler pool or the primary master, depending on architecture"
 }


### PR DESCRIPTION
Not all required data was being returned when private IP addresses were
combined with standard installations.