### PR TITLE
Enable custom DNS with internalDNS pattern

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,4 +133,5 @@ module "instances" {
   compiler_disk      = data.hiera5.compiler_disk.value
   primary_disk       = data.hiera5.primary_disk.value
   database_disk      = data.hiera5.database_disk.value
+  domain_name        = var.domain_name
 }

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -42,7 +42,8 @@ locals {
   servers = [ for i in flatten([
     aws_instance.server[*],
     aws_instance.psql[*],
-    aws_instance.compiler[*]
+    aws_instance.compiler[*],
+    aws_instance.node[*]
   ]) :
     [ i.id,
     var.domain_name == null ? i.private_dns :
@@ -156,6 +157,10 @@ resource "aws_instance" "node" {
   tags                   = merge(local.tags, tomap({
     "Name" = "pe-node-${count.index}-${var.id}"
   }))
+
+  lifecycle {
+    ignore_changes = [tags["internalDNS"]]
+  }
 
   root_block_device {
     volume_size = 15

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -85,3 +85,8 @@ variable "database_disk" {
   description = "Instance disk size of PuppetDB database and replica"
   type        = string
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,8 @@ variable "disable_lb" {
   type        = bool
   default     = false
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Commit implements a soltuion for leveraging the internalDNS pattern in AWS which we use in GCP and Azure modules. This allows us the ability to query node metadata for inventory generation in Bolt.