### PR TITLE
Add global tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.32.0"
+      version = "3.36.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This PR makes the tags global so they are automatically applied to all resources, not only to instances.
For this to work, the AWS provider needed to be updated.